### PR TITLE
(fix) isAcyclic: Was throwing exception for the wrong reason

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -86,19 +86,19 @@ DirectedGraph.prototype.dfs = function (to_find, node, DirectedGraph) {
         i = 0,
         child,
         found;
-    
+
     if (t_1 === undefined || t_2 === undefined) {
         return null;
     }
-    
+
     if (t_1.name === t_2.name) {
         return t_1;
     }
-    
+
     for (i = 0; i < edges_out.length; i += 1) {
         children.push(edges_out[i].to);
     }
-        
+
     for (i = 0; i < children.length; i += 1) {
         child = children[i];
         found = DirectedGraph.dfs(to_find, child, DirectedGraph);
@@ -177,7 +177,7 @@ DirectedGraph.prototype.tSort = function () {
 
 DirectedGraph.prototype.isAcyclic = function () {
     try {
-        t_DirectedGraph.tSort();
+        tDirectedGraph.sort();
     }
     catch(e) {
         return false;
@@ -191,7 +191,7 @@ DirectedGraph.prototype.loadTasks = function() {
     //next steps:
     //  allow for specific nodes to be considered
     //  allow for dependencies
-    //  throw special errors! 
+    //  throw special errors!
     for(var i = 0; i<this.nodes.length; i++) {
         var n = this.nodes[i];
         var name = n.name;
@@ -209,13 +209,13 @@ DirectedGraph.prototype.loadTasks = function() {
             });
         }
     }
-}          
+}
 */
 /*
     you can now run tasks with
     orchestrator.start('thing1', 'thing2', function (err) {
         if(err) throw err;
-        //done! 
+        //done!
     });
 */
 
@@ -242,8 +242,8 @@ DirectedGraph.errors = {
 
 function DirectedGraph(struct) {
     'use strict';
-    
-    //having a structure is also optional    
+
+    //having a structure is also optional
     if (typeof struct !== "undefined") {
         this.nodes = struct.nodes;
         this.edges = struct.edges;
@@ -256,20 +256,20 @@ function DirectedGraph(struct) {
     var test = validator.validate({nodes: this.nodes, edges: this.edges}, scheme),
         uq = areUq(this.edges, 'name'),
         x;
-    
+
     if (test.errors.length > 0) {
         throw new ValidationError('Validation of DirectedGraph Failed: ', test.errors);
     }
-        
+
     if (uq.length !== 0) {
         throw new ValidationError('Duplicate Edges Found: ', uq);
     }
-    
+
     x = hangingEdges(this, this.edges);
     if (x.length !== 0) {
         throw new ValidationError('Hanging Edges Found: ', x);
     }
-        
+
     //initial edge adding to tDirectedGraph
     for(var i = 0; i < this.edges.length; i++) {
         var x = this.edges[i];
@@ -338,7 +338,7 @@ UndirectedGraph.prototype.addNode = function(name, dt) {
 
 /*
 important - edge structure is NOT the same as DAG
-between is an array of two nodes- the nodes that the edges connect. 
+between is an array of two nodes- the nodes that the edges connect.
 */
 UndirectedGraph.prototype.addEdge = function(name, n1, n2, dt) {
     //data (dt) is optional
@@ -393,8 +393,8 @@ UndirectedGraph.errors = {
 // TODO: add validation of an UndirectedGraph
 function UndirectedGraph(struct) {
     'use strict';
-    
-    //having a structure is also optional    
+
+    //having a structure is also optional
     if (typeof struct !== "undefined") {
         this.nodes = struct.nodes;
         this.edges = struct.edges;
@@ -406,7 +406,7 @@ function UndirectedGraph(struct) {
 
     //need to add a scheme validator
     var uq = areUq(this.edges, 'name');
-        
+
     if (uq.length !== 0) {
         throw new ValidationError('Duplicate Edges Found: ', uq);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-json",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A JSON-format backed graph with preliminary identification algorithms.",
   "main": "lib/graph.js",
   "scripts": {


### PR DESCRIPTION
The isAcyclic check was testing an object that didn't exist. This update switches the method to use the proper tsort object.
